### PR TITLE
Port the sanitise method over

### DIFF
--- a/lib/file_storage/uri_builder.rb
+++ b/lib/file_storage/uri_builder.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module FileStorage
+  module UriBuilder
+    # Sanitizes the input as not all characters are valid as either URIs or as bucket keys.
+    # When we get them we want to replace them with something Nexus can process.
+    #
+    # @param input [String] the string to sanitise
+    # @param [String] replacement the replacement string for invalid characters
+    # @return [String] the sanitised string
+    def self.sanitize(input, replacement = "__")
+      input.gsub(/[{}<>]/, replacement)
+    end
+  end
+end

--- a/spec/file_storage/uri_builder_spec.rb
+++ b/spec/file_storage/uri_builder_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "file_storage/uri_builder"
+
+RSpec.describe FileStorage::UriBuilder do
+  describe "#sanitize" do
+    subject { described_class.sanitize(input) }
+
+    context "when there's nothing to replace" do
+      let(:input) { "everything is good" }
+
+      it { is_expected.to(eq(input)) }
+    end
+
+    context "when the input contains characters we cannot process" do
+      let(:input) { "everything is {not} good <enough>" }
+
+      it { is_expected.to(eq("everything is __not__ good __enough__")) }
+
+      context "and we have specified a different replacement" do
+        subject { described_class.sanitize(input, "!!") }
+
+        it { is_expected.to(eq("everything is !!not!! good !!enough!!")) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This was left out of #2 but looks like it can be generally useful.
Minor addition is the option to define a different replacement string
but the default will stay unchanged so this is backwards compatible.