### PR TITLE
Be more precise in what ruby version we support

### DIFF
--- a/file_storage.gemspec
+++ b/file_storage.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.authors     = ["GoCardless Engineering"]
   s.email       = ["developers@gocardless.com"]
   s.summary     = "A helper library to access cloud storage services"
-  s.required_ruby_version = ">= 2.7"
+  s.required_ruby_version = ">= 2.7.0"
   s.description = <<-DESCRIPTION
     A helper library to access cloud storage services such as Google Cloud Storage.
   DESCRIPTION


### PR DESCRIPTION
I'm fairly sure this should work by looking at the specs
(https://guides.rubygems.org/specification-reference/#required_ruby_version=)
but apparently it's breaking dependabot... (see https://app.dependabot.com/accounts/gocardless/update-logs/45078207)