### PR TITLE
Disable required ruby version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,3 +29,8 @@ RSpec/LetSetup:
 
 RSpec/MultipleExpectations:
   Max: 10
+
+# Disabled as it's breaking dependabot 
+Gemspec/RequiredRubyVersion:
+  Exclude:
+    - 'file_storage.gemspec'

--- a/file_storage.gemspec
+++ b/file_storage.gemspec
@@ -8,7 +8,6 @@ Gem::Specification.new do |s|
   s.authors     = ["GoCardless Engineering"]
   s.email       = ["developers@gocardless.com"]
   s.summary     = "A helper library to access cloud storage services"
-  s.required_ruby_version = ">= 2.7.0"
   s.description = <<-DESCRIPTION
     A helper library to access cloud storage services such as Google Cloud Storage.
   DESCRIPTION


### PR DESCRIPTION
It's still breaking dependabot. I think it's a subtle hint that we need
to move over the github version, but for now it's probably worth
disabling this cop entirely as it's an internal gem.