### PR TITLE
Allow dependabot to update dependencies

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,3 +4,7 @@ update_configs:
   - package_manager: "ruby:bundler"
     directory: "/"
     update_schedule: "weekly"
+    version_requirement_updates: auto
+    allowed_updates:
+      - match:
+          update_type: "all" # Include tansitive/sub-dependencies


### PR DESCRIPTION
We're getting these messages in dependabot's update log for basically
everything in the `.gemspec` file:

```
updater | INFO <job_48951406> Requirements to unlock update_not_possible
updater | INFO <job_48951406> Requirements update strategy bump_versions_if_necessary
updater | INFO <job_48951406> No update possible for rubocop-performance
```

I'm not sure why this is happening, but looking at other projects we are
not defining a couple of properties, which this commit is adding.