### PR TITLE
Adjust activesupport version limits

### DIFF
--- a/file_storage.gemspec
+++ b/file_storage.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["lib/**/*", "README.md"]
 
-  s.add_dependency "activesupport", "~> 6.0.3"
+  s.add_dependency "activesupport", ">= 6.0", "< 7"
   s.add_dependency "google-cloud-storage", "~> 1.29"
 
   s.add_development_dependency "gc_ruboconfig", "~> 2.20"


### PR DESCRIPTION
With rails 6.1 round the corner we can unpin this