### PR TITLE
Make `.exists` slightly faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 v0.5.0
 ------
 - Support escaping of URI keys. Fixes #46.
+- Slightly improve the performance of `.exists`
 
 v0.4.0
 ------

--- a/lib/bucket_store/key_storage.rb
+++ b/lib/bucket_store/key_storage.rb
@@ -153,7 +153,7 @@ module BucketStore
     #
     # @return [bool] `true` if the given key exists, `false` if not
     def exists?
-      list.first == "#{adapter_type}://#{bucket}/#{key}"
+      list(page_size: 1).first == "#{adapter_type}://#{bucket}/#{key}"
     end
 
     private


### PR DESCRIPTION
Because we're only interested in an exact match, we only need to return
one item from `.list`, which makes the response smaller and therefore
it's a bit faster in practice