### PR TITLE
Support running integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,29 @@ jobs:
           name: Run specs
           command: bundle exec rspec
 
+  integration:
+    parameters:
+      ruby_version:
+        type: string
+    docker:
+      - image: circleci/ruby:<< parameters.ruby_version >>
+      - image: quay.io/minio/minio
+        environment:
+          MINIO_ROOT_USER: minioadmin
+          MINIO_ROOT_PASSWORD: minioadmin
+          MINIO_REGION_NAME: us-east-1
+        entrypoint: /bin/bash
+        command: -c "mkdir -p /data/bucket && minio server /data --console-address \":9001\""
+    steps:
+      - add_ssh_keys
+      - checkout
+      - *restore_bundle
+      - *bundle_install
+      - *cache_bundle
+      - run:
+          name: Run specs
+          command: bundle exec rspec --tag integration
+
 workflows:
   version: 2
   tests:
@@ -63,6 +86,10 @@ workflows:
             parameters:
               ruby_version: ["3.0"]
       - rspec:
+          matrix:
+            parameters:
+              ruby_version: ["2.6", "2.7", "3.0"]
+      - integration:
           matrix:
             parameters:
               ruby_version: ["2.6", "2.7", "3.0"]

--- a/README.md
+++ b/README.md
@@ -159,6 +159,15 @@ BucketStore.for("inmemory://bucket/path/file.xml").delete!
 => true
 ```
 
+## Development
+
+### Running tests
+BucketStore comes with both unit and integration tests. While unit tests can be run by simply
+executing `bundle exec rspec`, integration tests require running minio locally. We provide an
+helper script (`scripts/run-minio.sh`) that spins up a pre-configured docker container with
+a single test bucket. Once minio has started, integration tests can be executed with
+`bundle exec rspec --tag integration`.
+
 ## License & Contributing
 
 * BucketStore is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/scripts/run-minio.sh
+++ b/scripts/run-minio.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Runs a minio server as a docker container with default credentials (minioadmin/minioadmin)
+# and a single bucket ("bucket").
+
+docker run --rm -t -i \
+  --name minio-bucketstore \
+  -p 9000:9000 \
+  -p 9001:9001 \
+  -e "MINIO_ROOT_USER=minioadmin" \
+  -e "MINIO_ROOT_PASSWORD=minioadmin" \
+  -e "MINIO_REGION_NAME=us-east-1" \
+  --entrypoint bash \
+  quay.io/minio/minio -c "\
+  mkdir -p /data/bucket && \
+  minio server /data --console-address \":9001\"
+  "

--- a/spec/bucket_store_integration_spec.rb
+++ b/spec/bucket_store_integration_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "aws-sdk-s3"
+
+RSpec.describe BucketStore, :integration do
+  before do
+    # Setup AWS connectivity to minio
+    Aws.config.update(
+      endpoint: "http://localhost:9000",
+      region: "us-east-1",
+
+      # default credentials for minio
+      access_key_id: "minioadmin",
+      secret_access_key: "minioadmin",
+
+      # required for minio as otherwise the client will try to resolve `bucketname.localhost:9000`
+      force_path_style: true,
+    )
+  end
+
+  shared_examples "adapter integration" do |base_bucket_uri|
+    # This is presented as a single idempotent test as otherwise resetting state between execution
+    # makes things very complicated with no huge benefits.
+
+    it "has a consistent interface" do
+      # Write 2001 files
+      file_list = []
+      2001.times do |i|
+        filename = "file#{(i + 1).to_s.rjust(4, '0')}.txt"
+        file_list << filename
+
+        # the body of the file is the filename itself
+        described_class.for("#{base_bucket_uri}/prefix/#{filename}").upload!(filename)
+      end
+
+      # List with prefix should only return the matching files
+      expect(described_class.for("#{base_bucket_uri}/prefix/file1").list.to_a.size).to eq(1000)
+      expect(described_class.for("#{base_bucket_uri}/prefix/file2").list.to_a.size).to eq(2)
+      expect(described_class.for("#{base_bucket_uri}/prefix/").list.to_a.size).to eq(2001)
+
+      # List (without prefixes) should return everything
+      expect(described_class.for(base_bucket_uri.to_s).list.to_a).
+        to eq(file_list.map { |filename| "#{base_bucket_uri}/prefix/#{filename}" })
+
+      # We know the content of the file, we can check `.download` returns it as expected
+      all_files = file_list.map do |filename|
+        [filename, "#{base_bucket_uri}/prefix/#{filename}"]
+      end
+      all_files.each do |content, key|
+        expect(described_class.for(key).download[:content]).to eq(content)
+      end
+
+      # Delete all the files, the bucket should be empty afterwards
+      file_list.map { |filename| "#{base_bucket_uri}/prefix/#{filename}" }.each do |key|
+        described_class.for(key).delete!
+      end
+      expect(described_class.for(base_bucket_uri.to_s).list.to_a.size).to eq(0)
+    end
+  end
+
+  # We don't test GCS as there's no sensible way of running a local simulator
+  include_examples "adapter integration", "inmemory://bucket"
+  include_examples "adapter integration", "disk://bucket"
+  include_examples "adapter integration", "s3://bucket"
+end

--- a/spec/bucket_store_integration_spec.rb
+++ b/spec/bucket_store_integration_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe BucketStore, :integration do
     # makes things very complicated with no huge benefits.
 
     it "has a consistent interface" do
-      # Write 2001 files
+      # Write 201 files
       file_list = []
-      2001.times do |i|
-        filename = "file#{(i + 1).to_s.rjust(4, '0')}.txt"
+      201.times do |i|
+        filename = "file#{(i + 1).to_s.rjust(3, '0')}.txt"
         file_list << filename
 
         # the body of the file is the filename itself
@@ -36,9 +36,9 @@ RSpec.describe BucketStore, :integration do
       end
 
       # List with prefix should only return the matching files
-      expect(described_class.for("#{base_bucket_uri}/prefix/file1").list.to_a.size).to eq(1000)
+      expect(described_class.for("#{base_bucket_uri}/prefix/file1").list.to_a.size).to eq(100)
       expect(described_class.for("#{base_bucket_uri}/prefix/file2").list.to_a.size).to eq(2)
-      expect(described_class.for("#{base_bucket_uri}/prefix/").list.to_a.size).to eq(2001)
+      expect(described_class.for("#{base_bucket_uri}/prefix/").list.to_a.size).to eq(201)
 
       # List (without prefixes) should return everything
       expect(described_class.for(base_bucket_uri.to_s).list.to_a).

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,14 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = "random"
 
+  if config.filter_manager.exclusions.rules.empty?
+    # Do not run integration tests unless an explicit `--tag` is set. This means
+    # that running `bundle exec rspec` will only run the unit tests, which is the
+    # generally preferred behaviour since integration tests require additional
+    # setup to run.
+    config.filter_run_excluding :integration
+  end
+
   # Silence log output when running tests
   BucketStore.configuration.logger = Logger.new(nil)
 


### PR DESCRIPTION
The integration tests right now are not the greatest, but it's a good starting point to ensure we provide a consistent interface across the adapters. I couldn't figure out a way to test GCS too but this works with everything else.