### PR TITLE
Support escapable URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v0.5.0
+------
+- Support escaping of URI keys. Fixes #46.
+
 v0.4.0
 ------
 - Add an `.exists?` method that returns `true`/`false` depending on whether a given

--- a/lib/bucket_store.rb
+++ b/lib/bucket_store.rb
@@ -4,6 +4,7 @@ require "bucket_store/version"
 require "bucket_store/configuration"
 require "bucket_store/key_context"
 require "bucket_store/key_storage"
+require "bucket_store/uri_builder"
 
 # An abstraction layer on the top of file cloud storage systems such as Google Cloud
 # Storage or S3. This module exposes a generic interface that allows interoperability

--- a/lib/bucket_store.rb
+++ b/lib/bucket_store.rb
@@ -41,8 +41,8 @@ module BucketStore
     # Given a `key` in the format of `adapter://bucket/key` returns the corresponding
     # adapter that will allow to manipulate (e.g. download, upload or list) such key.
     #
-    # Currently supported adapters are `gs` (Google Cloud Storage), `inmemory` (an
-    # in-memory key-value storage) and `disk` (a disk-backed key-value store).
+    # Currently supported adapters are `gs` (Google Cloud Storage), `s3` (AWS S3),
+    # `inmemory` (an in-memory key-value storage) and `disk` (a disk-backed key-value store).
     #
     # @param [String] key The reference key
     # @return [KeyStorage] An interface to the adapter that can handle requests on the given key

--- a/lib/bucket_store/disk.rb
+++ b/lib/bucket_store/disk.rb
@@ -78,7 +78,7 @@ module BucketStore
     end
 
     def sanitize_filename(filename)
-      filename.gsub(%r{[^0-9A-z.\-/]}, "_")
+      filename.gsub(%r{[^0-9A-z.\- /]}, "_")
     end
   end
 end

--- a/lib/bucket_store/key_context.rb
+++ b/lib/bucket_store/key_context.rb
@@ -19,18 +19,35 @@ module BucketStore
     end
 
     def self.parse(raw_key)
-      uri = URI(raw_key)
+      uri = URI(escape(raw_key))
+
+      scheme = unescape(uri.scheme)
+      bucket = unescape(uri.host)
 
       # A key should never be `nil` but can be empty. Depending on the operation, this may
       # or may not be a valid configuration (e.g. an empty key is likely valid on a
       # `list`, but not during a `download`).
-      key = uri.path.sub!(%r{/}, "") || ""
+      key = unescape(uri.path).sub!(%r{/}, "") || ""
 
-      raise KeyParseException if [uri.scheme, uri.host, key].map(&:nil?).any?
+      raise KeyParseException if [scheme, bucket, key].map(&:nil?).any?
 
-      KeyContext.new(adapter: uri.scheme,
-                     bucket: uri.host,
+      KeyContext.new(adapter: scheme,
+                     bucket: bucket,
                      key: key)
     end
+
+    def self.escape(key)
+      return key if key.nil?
+
+      URI::DEFAULT_PARSER.escape(key)
+    end
+    private_class_method :escape
+
+    def self.unescape(key)
+      return key if key.nil?
+
+      URI::DEFAULT_PARSER.unescape(key)
+    end
+    private_class_method :unescape
   end
 end

--- a/lib/bucket_store/version.rb
+++ b/lib/bucket_store/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BucketStore
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/spec/bucket_store/disk_spec.rb
+++ b/spec/bucket_store/disk_spec.rb
@@ -55,6 +55,17 @@ RSpec.describe BucketStore::Disk do
         )
       end
     end
+
+    context "when given a key with invalid chars" do
+      it "sanitizes the filename" do
+        instance.upload!(bucket: bucket, key: "this is % invalid", content: "%%%%")
+
+        expect(instance.list(bucket: bucket, key: "", page_size: 1000).first).to match(
+          bucket: bucket,
+          keys: ["this is _ invalid"],
+        )
+      end
+    end
   end
 
   describe "#download" do

--- a/spec/bucket_store/key_context_spec.rb
+++ b/spec/bucket_store/key_context_spec.rb
@@ -45,6 +45,28 @@ RSpec.describe BucketStore::KeyContext do
           expect(instance.key).to eq("")
         end
       end
+
+      context "with characters that would need to be escaped" do
+        context "with a space" do
+          let(:key) { "scheme://bucket/hello world" }
+
+          it "parses the key" do
+            expect(instance.adapter).to eq("scheme")
+            expect(instance.bucket).to eq("bucket")
+            expect(instance.key).to eq("hello world")
+          end
+        end
+
+        context "with a %" do
+          let(:key) { "scheme://bucket/hello%world" }
+
+          it "parses the key" do
+            expect(instance.adapter).to eq("scheme")
+            expect(instance.bucket).to eq("bucket")
+            expect(instance.key).to eq("hello%world")
+          end
+        end
+      end
     end
   end
 end

--- a/spec/bucket_store_integration_spec.rb
+++ b/spec/bucket_store_integration_spec.rb
@@ -35,14 +35,23 @@ RSpec.describe BucketStore, :integration do
         described_class.for("#{base_bucket_uri}/prefix/#{filename}").upload!(filename)
       end
 
+      # Add some files with spaces
+      described_class.for("#{base_bucket_uri}/prefix/i have a space.txt").
+        upload!("i have a space.txt")
+      described_class.for("#{base_bucket_uri}/prefix/another space.txt").
+        upload!("another space.txt")
+
+      file_list << "i have a space.txt"
+      file_list << "another space.txt"
+
       # List with prefix should only return the matching files
       expect(described_class.for("#{base_bucket_uri}/prefix/file1").list.to_a.size).to eq(100)
       expect(described_class.for("#{base_bucket_uri}/prefix/file2").list.to_a.size).to eq(2)
-      expect(described_class.for("#{base_bucket_uri}/prefix/").list.to_a.size).to eq(201)
+      expect(described_class.for("#{base_bucket_uri}/prefix/").list.to_a.size).to eq(203)
 
       # List (without prefixes) should return everything
       expect(described_class.for(base_bucket_uri.to_s).list.to_a).
-        to eq(file_list.map { |filename| "#{base_bucket_uri}/prefix/#{filename}" })
+        to match_array(file_list.map { |filename| "#{base_bucket_uri}/prefix/#{filename}" })
 
       # We know the content of the file, we can check `.download` returns it as expected
       all_files = file_list.map do |filename|


### PR DESCRIPTION
Passing an URI that needs to be escaped to BucketStore will result in an
error. For example the following will raise an `URI::InvalidURIError`.

```ruby
BucketStore.for("s3://bucket/a key with spaces.txt")
```

This commit adds support for internal escape/unescape of URIs, meaning
that external callers don't need to worry about passing unescaped values
to `.for`.

Fixes #46.