### PR TITLE
Allow configuration of the disk adapter base dir via the config class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v0.6.0
+------
+- Allow overriding the disk adapter base directory via the configuration class.
+
 v0.5.0
 ------
 - Support escaping of URI keys. Fixes #46.

--- a/lib/bucket_store/configuration.rb
+++ b/lib/bucket_store/configuration.rb
@@ -15,5 +15,20 @@ module BucketStore
     #   config.logger = Logger.new($stderr)
     # @!attribute logger
     attr_writer :logger
+
+    def disk_adapter_base_directory
+      @disk_adapter_base_directory ||= ENV["DISK_ADAPTER_BASE_DIR"] || Dir.tmpdir
+    end
+
+    # Specifies the location of the disk adapter's base directory.
+    #
+    # If `DISK_ADAPTER_BASE_DIR` is given as an environment variable, its value
+    # will be used as a default value. Otherwise this will be equal to the operating
+    # system's default temporary file path.
+    #
+    # @example Create a temporary directory for the disk adapter
+    #   config.disk_adapter_base_directory = Dir.mktmpdir
+    # @!attribute disk_adapter_base_directory
+    attr_writer :disk_adapter_base_directory
   end
 end

--- a/lib/bucket_store/disk.rb
+++ b/lib/bucket_store/disk.rb
@@ -4,8 +4,7 @@ require "fileutils"
 
 module BucketStore
   class Disk
-    def self.build(base_dir = ENV["DISK_ADAPTER_BASE_DIR"])
-      base_dir ||= Dir.tmpdir
+    def self.build(base_dir = BucketStore.configuration.disk_adapter_base_directory)
       Disk.new(base_dir)
     end
 


### PR DESCRIPTION
This allows the base directory for the disk adapter to be changed at
runtime in addition to setting it up via an environment variable, which
is quite useful when the disk adapter is used for testing.