### PR TITLE
Drop support for Ruby 2.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,12 +84,12 @@ workflows:
       - code_quality:
           matrix:
             parameters:
-              ruby_version: ["2.6"]
+              ruby_version: ["2.7"]
       - rspec:
           matrix:
             parameters:
-              ruby_version: ["2.6", "2.7", "3.0", "3.1"]
+              ruby_version: ["2.7", "3.0", "3.1"]
       - integration:
           matrix:
             parameters:
-              ruby_version: ["2.6", "2.7", "3.0", "3.1"]
+              ruby_version: ["2.7", "3.0", "3.1"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v0.6.0
+------
+- Drop support for Ruby 2.6
+
 v0.5.0
 ------
 - Support escaping of URI keys. Fixes #46.

--- a/bucket_store.gemspec
+++ b/bucket_store.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["lib/**/*", "README.md"]
 
-  s.required_ruby_version = ">= 2.6"
+  s.required_ruby_version = ">= 2.7"
 
   s.add_dependency "aws-sdk-s3", ">= 1.104"
   s.add_dependency "google-cloud-storage", ">= 1.34"

--- a/bucket_store.gemspec
+++ b/bucket_store.gemspec
@@ -28,4 +28,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rubocop", "~> 1.24"
   s.add_development_dependency "rubocop-performance", "~> 1.13"
   s.add_development_dependency "rubocop-rspec", "~> 2.7"
+
+  s.metadata["rubygems_mfa_required"] = "true"
 end

--- a/bucket_store.gemspec
+++ b/bucket_store.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "aws-sdk-s3", ">= 1.104"
   s.add_dependency "google-cloud-storage", ">= 1.34"
 
-  s.add_development_dependency "gc_ruboconfig", "~> 2.29"
+  s.add_development_dependency "gc_ruboconfig", "~> 3.1"
   s.add_development_dependency "pry-byebug", "~> 3.9"
   s.add_development_dependency "rspec", "~> 3.10"
   s.add_development_dependency "rspec_junit_formatter", "~> 0.5.1"

--- a/lib/bucket_store/version.rb
+++ b/lib/bucket_store/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BucketStore
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end


### PR DESCRIPTION
Ruby 2.6 has reached EOL - as per policy we don't support support EOL
ruby versions and therefore we can drop 2.6 support from future
releases.