### PR TITLE
Support streaming uploads and downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 v0.6.0
 ------
 - [BREAKING] Remove support for Ruby 2.6
-- Add support for streaming upoads / downloads
+- Add support for streaming uploads / downloads
 
 v0.5.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v0.6.0
+------
+- [BREAKING] Remove support for Ruby 2.6
+- Add support for streaming upoads / downloads
+
 v0.5.0
 ------
 - Support escaping of URI keys. Fixes #46.

--- a/README.md
+++ b/README.md
@@ -135,16 +135,32 @@ in mind:
 
 ## Examples
 
-### Uploading a file to a bucket
+### Uploading a string to a bucket
 ```ruby
 BucketStore.for("inmemory://bucket/path/file.xml").upload!("hello world")
 => "inmemory://bucket/path/file.xml"
 ```
 
-### Accessing a file in a bucket
+### Accessing a string in a bucket
 ```ruby
 BucketStore.for("inmemory://bucket/path/file.xml").download
 => {:bucket=>"bucket", :key=>"path/file.xml", :content=>"hello world"}
+```
+
+### Uploading a file-like object to a bucket
+```ruby
+buffer = StringIO.new("This could also be an actual file")
+BucketStore.for("inmemory://bucket/path/file.xml").stream.upload!(file: buffer)
+=> "inmemory://bucket/path/file.xml"
+```
+
+### Downloading to a file-like object from a bucket
+```ruby
+buffer = StringIO.new
+BucketStore.for("inmemory://bucket/path/file.xml").stream.download(file: buffer)
+=> {:bucket=>"bucket", :key=>"path/file.xml", :file=>buffer}
+buffer.string 
+=> "This could also be an actual file"
 ```
 
 ### Listing all keys under a prefix

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       MINIO_REGION_NAME: us-east-1
     ports:
       - "9000:9000"
+      - "9001:9001"
   gcp-simulator:
     image: fsouza/fake-gcs-server
     hostname: gcp

--- a/lib/bucket_store/disk.rb
+++ b/lib/bucket_store/disk.rb
@@ -13,9 +13,9 @@ module BucketStore
       @base_dir = File.expand_path(base_dir)
     end
 
-    def upload!(bucket:, key:, content:)
-      File.open(key_path(bucket, key), "w") do |file|
-        file.write(content)
+    def upload!(bucket:, key:, file:)
+      File.open(key_path(bucket, key), "w") do |output_file|
+        output_file.write(file.read)
       end
       {
         bucket: bucket,

--- a/lib/bucket_store/disk.rb
+++ b/lib/bucket_store/disk.rb
@@ -16,7 +16,11 @@ module BucketStore
     def upload!(bucket:, key:, file:)
       File.open(key_path(bucket, key), "w") do |output_file|
         output_file.write(file.read)
+        output_file.rewind
       end
+
+      file.rewind
+
       {
         bucket: bucket,
         key: key,
@@ -26,6 +30,8 @@ module BucketStore
     def download(bucket:, key:, file:)
       File.open(key_path(bucket, key), "r") do |saved_file|
         file.write(saved_file.read)
+        saved_file.rewind
+        file.rewind
       end
     end
 

--- a/lib/bucket_store/disk.rb
+++ b/lib/bucket_store/disk.rb
@@ -19,8 +19,6 @@ module BucketStore
         output_file.rewind
       end
 
-      file.rewind
-
       {
         bucket: bucket,
         key: key,
@@ -30,7 +28,6 @@ module BucketStore
     def download(bucket:, key:, file:)
       File.open(key_path(bucket, key), "r") do |saved_file|
         file.write(saved_file.read)
-        saved_file.rewind
         file.rewind
       end
     end

--- a/lib/bucket_store/disk.rb
+++ b/lib/bucket_store/disk.rb
@@ -23,13 +23,9 @@ module BucketStore
       }
     end
 
-    def download(bucket:, key:)
-      File.open(key_path(bucket, key), "r") do |file|
-        {
-          bucket: bucket,
-          key: key,
-          content: file.read,
-        }
+    def download(bucket:, key:, file:)
+      File.open(key_path(bucket, key), "r") do |saved_file|
+        file.write(saved_file.read)
       end
     end
 

--- a/lib/bucket_store/gcs.rb
+++ b/lib/bucket_store/gcs.rb
@@ -36,6 +36,8 @@ module BucketStore
     def upload!(bucket:, key:, file:)
       get_bucket(bucket).create_file(file, key)
 
+      file.rewind
+
       {
         bucket: bucket,
         key: key,
@@ -43,9 +45,13 @@ module BucketStore
     end
 
     def download(bucket:, key:, file:)
-      get_bucket(bucket).
-        file(key).
-        download(file)
+      file.tap do |f|
+        get_bucket(bucket).
+          file(key).
+          download(f)
+
+        f.rewind
+      end
     end
 
     def list(bucket:, key:, page_size:)

--- a/lib/bucket_store/gcs.rb
+++ b/lib/bucket_store/gcs.rb
@@ -42,17 +42,10 @@ module BucketStore
       }
     end
 
-    def download(bucket:, key:)
-      file = get_bucket(bucket).file(key)
-
-      buffer = StringIO.new
-      file.download(buffer)
-
-      {
-        bucket: bucket,
-        key: key,
-        content: buffer.string,
-      }
+    def download(bucket:, key:, file:)
+      get_bucket(bucket).
+        file(key).
+        download(file)
     end
 
     def list(bucket:, key:, page_size:)

--- a/lib/bucket_store/gcs.rb
+++ b/lib/bucket_store/gcs.rb
@@ -36,8 +36,6 @@ module BucketStore
     def upload!(bucket:, key:, file:)
       get_bucket(bucket).create_file(file, key)
 
-      file.rewind
-
       {
         bucket: bucket,
         key: key,

--- a/lib/bucket_store/gcs.rb
+++ b/lib/bucket_store/gcs.rb
@@ -33,9 +33,8 @@ module BucketStore
                  end
     end
 
-    def upload!(bucket:, key:, content:)
-      buffer = StringIO.new(content)
-      get_bucket(bucket).create_file(buffer, key)
+    def upload!(bucket:, key:, file:)
+      get_bucket(bucket).create_file(file, key)
 
       {
         bucket: bucket,

--- a/lib/bucket_store/in_memory.rb
+++ b/lib/bucket_store/in_memory.rb
@@ -34,7 +34,10 @@ module BucketStore
     end
 
     def download(bucket:, key:, file:)
-      file.write(@buckets[bucket].fetch(key))
+      file.tap do |f|
+        f.write(@buckets[bucket].fetch(key))
+        f.rewind
+      end
     end
 
     def list(bucket:, key:, page_size:)

--- a/lib/bucket_store/in_memory.rb
+++ b/lib/bucket_store/in_memory.rb
@@ -27,7 +27,6 @@ module BucketStore
     def upload!(bucket:, key:, file:)
       file.tap do |f|
         @buckets[bucket][key] = f.read
-        f.rewind
       end
 
       {

--- a/lib/bucket_store/in_memory.rb
+++ b/lib/bucket_store/in_memory.rb
@@ -24,8 +24,8 @@ module BucketStore
       @buckets = Hash.new { |hash, key| hash[key] = {} }
     end
 
-    def upload!(bucket:, key:, content:)
-      @buckets[bucket][key] = content
+    def upload!(bucket:, key:, file:)
+      @buckets[bucket][key] = file.read
 
       {
         bucket: bucket,

--- a/lib/bucket_store/in_memory.rb
+++ b/lib/bucket_store/in_memory.rb
@@ -25,7 +25,10 @@ module BucketStore
     end
 
     def upload!(bucket:, key:, file:)
-      @buckets[bucket][key] = file.read
+      file.tap do |f|
+        @buckets[bucket][key] = f.read
+        f.rewind
+      end
 
       {
         bucket: bucket,

--- a/lib/bucket_store/in_memory.rb
+++ b/lib/bucket_store/in_memory.rb
@@ -33,12 +33,8 @@ module BucketStore
       }
     end
 
-    def download(bucket:, key:)
-      {
-        bucket: bucket,
-        key: key,
-        content: @buckets[bucket].fetch(key),
-      }
+    def download(bucket:, key:, file:)
+      file.write(@buckets[bucket].fetch(key))
     end
 
     def list(bucket:, key:, page_size:)

--- a/lib/bucket_store/key_storage.rb
+++ b/lib/bucket_store/key_storage.rb
@@ -53,34 +53,40 @@ module BucketStore
       result
     end
 
-    # Uploads the given content to the reference key location.
+    # Uploads the given file to the reference key location.
+    # If the File is a file like object then upload as is.
+    # If the file variable is actually a string then treat is as the file
+    # contents and upload as is.
     #
     # If the `key` already exists, its content will be replaced by the one in input.
     #
-    # @param [String] content The content to upload
+    # @param [String or File like object] file The file like object to upload or a String
+    #         with the contents
     # @return [String] The final `key` where the content has been uploaded
     # @example Upload a file
     #   BucketStore.for("inmemory://bucket/file.xml").upload!("hello world")
-    def upload!(content)
-      do_upload!(
-        StringIO.new(content),
-        "upload",
-      )
-    end
+    def upload!(file)
+      raise ArgumentError, "Key cannot be empty" if key.empty?
 
-    # Uploads the given file like object to the reference key location.
-    #
-    # If the `key` already exists, its content will be replaced by the one in input.
-    #
-    # @param [IO / file like] file The content to upload
-    # @return [String] The final `key` where the content has been uploaded
-    # @example Upload a file
-    #   BucketStore.for("inmemory://bucket/file.xml").upload_file!(File.open("my_file.txt", "r"))
-    def upload_file!(file)
-      do_upload!(
-        file,
-        "upload_file",
+      if file.instance_of?(String)
+        file = StringIO.new(file)
+      end
+
+      BucketStore.logger.info(event: "key_storage.upload_started",
+                              **log_context)
+
+      start = BucketStore::Timing.monotonic_now
+      result = adapter.upload!(
+        bucket: bucket,
+        key: key,
+        file: file,
       )
+
+      BucketStore.logger.info(event: "key_storage.upload_finished",
+                              duration: BucketStore::Timing.monotonic_now - start,
+                              **log_context)
+
+      "#{adapter_type}://#{result[:bucket]}/#{result[:key]}"
     end
 
     # Lists all keys for the current adapter that have the reference key as prefix
@@ -168,26 +174,6 @@ module BucketStore
         key: key,
         adapter_type: adapter_type,
       }.compact
-    end
-
-    def do_upload!(file, event_prefix)
-      raise ArgumentError, "Key cannot be empty" if key.empty?
-
-      BucketStore.logger.info(event: "key_storage.#{event_prefix}_started",
-                              **log_context)
-
-      start = BucketStore::Timing.monotonic_now
-      result = adapter.upload!(
-        bucket: bucket,
-        key: key,
-        file: file,
-      )
-
-      BucketStore.logger.info(event: "key_storage.#{event_prefix}_finished",
-                              duration: BucketStore::Timing.monotonic_now - start,
-                              **log_context)
-
-      "#{adapter_type}://#{result[:bucket]}/#{result[:key]}"
     end
   end
 end

--- a/lib/bucket_store/key_storage.rb
+++ b/lib/bucket_store/key_storage.rb
@@ -59,23 +59,15 @@ module BucketStore
     end
 
     # Uploads the given file to the reference key location.
-    # If the File is a file like object then upload as is.
-    # If the file variable is actually a string then treat is as the file
-    # contents and upload as is.
     #
     # If the `key` already exists, its content will be replaced by the one in input.
     #
-    # @param [String or File like object] file The file like object to upload or a String
-    #         with the contents
+    # @param [String] content Contents of the file
     # @return [String] The final `key` where the content has been uploaded
     # @example Upload a file
     #   BucketStore.for("inmemory://bucket/file.xml").upload!("hello world")
-    def upload!(file)
+    def upload!(content)
       raise ArgumentError, "Key cannot be empty" if key.empty?
-
-      if file.instance_of?(String)
-        file = StringIO.new(file)
-      end
 
       BucketStore.logger.info(event: "key_storage.upload_started",
                               **log_context)
@@ -84,7 +76,7 @@ module BucketStore
       result = adapter.upload!(
         bucket: bucket,
         key: key,
-        file: file,
+        file: StringIO.new(content),
       )
 
       BucketStore.logger.info(event: "key_storage.upload_finished",

--- a/lib/bucket_store/key_storage.rb
+++ b/lib/bucket_store/key_storage.rb
@@ -15,6 +15,88 @@ module BucketStore
       disk: Disk,
     }.freeze
 
+    # Defines a streaming interface for download and upload operations.
+    #
+    # Note that individual adapters may require additional configuration for the correct
+    # behavior of the streaming interface.
+    class KeyStreamer
+      attr_reader :bucket, :key, :adapter, :adapter_type
+
+      def initialize(adapter:, adapter_type:, bucket:, key:)
+        @adapter = adapter
+        @adapter_type = adapter_type
+        @bucket = bucket
+        @key = key
+      end
+
+      # Streams the content of the reference key into a File like object
+      #
+      # @return hash containing the bucket, the key and file like object passed in as input
+      #
+      # @see KeyStorage#download
+      # @example Download a key
+      #   buffer = StringIO.new
+      #   BucketStore.for("inmemory://bucket/file.xml").stream.download(file: buffer)
+      #   buffer.string == "Imagine I'm a 2GB file"
+      def download(file:)
+        BucketStore.logger.info(event: "key_storage.stream.download_started")
+
+        start = BucketStore::Timing.monotonic_now
+        adapter.download(
+          bucket: bucket,
+          key: key,
+          file: file,
+        )
+
+        BucketStore.logger.info(event: "key_storage.stream.download_finished",
+                                duration: BucketStore::Timing.monotonic_now - start)
+
+        {
+          bucket: bucket,
+          key: key,
+          file: file,
+        }
+      end
+
+      # Performs a streaming upload to the backing object store
+      #
+      # @return the generated key for the new object
+      #
+      # @see KeyStorage#upload!
+      # @example Upload a key
+      #   buffer = StringIO.new("Imagine I'm a 2GB file")
+      #   BucketStore.for("inmemory://bucket/file.xml").stream.upload!(file: buffer)
+      def upload!(file:)
+        raise ArgumentError, "Key cannot be empty" if key.empty?
+
+        BucketStore.logger.info(event: "key_storage.stream.upload_started",
+                                **log_context)
+
+        start = BucketStore::Timing.monotonic_now
+        adapter.upload!(
+          bucket: bucket,
+          key: key,
+          file: file,
+        )
+
+        BucketStore.logger.info(event: "key_storage.stream.upload_finished",
+                                duration: BucketStore::Timing.monotonic_now - start,
+                                **log_context)
+
+        "#{adapter_type}://#{bucket}/#{key}"
+      end
+
+      private
+
+      def log_context
+        {
+          bucket: bucket,
+          key: key,
+          adapter_type: adapter_type,
+        }.compact
+      end
+    end
+
     attr_reader :bucket, :key, :adapter_type
 
     def initialize(adapter:, bucket:, key:)
@@ -40,22 +122,11 @@ module BucketStore
     # @example Download a key
     #   BucketStore.for("inmemory://bucket/file.xml").download
     def download
-      raise ArgumentError, "Key cannot be empty" if key.empty?
-
-      BucketStore.logger.info(event: "key_storage.download_started")
-
-      start = BucketStore::Timing.monotonic_now
       buffer = StringIO.new
-      adapter.download(bucket: bucket, key: key, file: buffer)
-
-      BucketStore.logger.info(event: "key_storage.download_finished",
-                              duration: BucketStore::Timing.monotonic_now - start)
-
-      {
-        bucket: bucket,
-        key: key,
-        content: buffer.string,
-      }
+      stream.download(file: buffer).tap do |result|
+        result.delete(:file)
+        result[:content] = buffer.string
+      end
     end
 
     # Uploads the given file to the reference key location.
@@ -67,23 +138,16 @@ module BucketStore
     # @example Upload a file
     #   BucketStore.for("inmemory://bucket/file.xml").upload!("hello world")
     def upload!(content)
+      stream.upload!(file: StringIO.new(content))
+    end
+
+    # Returns an interface for streaming operations
+    #
+    # @return [KeyStreamer] An interface for streaming operations
+    def stream
       raise ArgumentError, "Key cannot be empty" if key.empty?
 
-      BucketStore.logger.info(event: "key_storage.upload_started",
-                              **log_context)
-
-      start = BucketStore::Timing.monotonic_now
-      result = adapter.upload!(
-        bucket: bucket,
-        key: key,
-        file: StringIO.new(content),
-      )
-
-      BucketStore.logger.info(event: "key_storage.upload_finished",
-                              duration: BucketStore::Timing.monotonic_now - start,
-                              **log_context)
-
-      "#{adapter_type}://#{result[:bucket]}/#{result[:key]}"
+      KeyStreamer.new(adapter: adapter, adapter_type: adapter_type, bucket: bucket, key: key)
     end
 
     # Lists all keys for the current adapter that have the reference key as prefix
@@ -164,13 +228,5 @@ module BucketStore
     private
 
     attr_reader :adapter
-
-    def log_context
-      {
-        bucket: bucket,
-        key: key,
-        adapter_type: adapter_type,
-      }.compact
-    end
   end
 end

--- a/lib/bucket_store/key_storage.rb
+++ b/lib/bucket_store/key_storage.rb
@@ -45,12 +45,17 @@ module BucketStore
       BucketStore.logger.info(event: "key_storage.download_started")
 
       start = BucketStore::Timing.monotonic_now
-      result = adapter.download(bucket: bucket, key: key)
+      buffer = StringIO.new
+      adapter.download(bucket: bucket, key: key, file: buffer)
 
       BucketStore.logger.info(event: "key_storage.download_finished",
                               duration: BucketStore::Timing.monotonic_now - start)
 
-      result
+      {
+        bucket: bucket,
+        key: key,
+        content: buffer.string,
+      }
     end
 
     # Uploads the given file to the reference key location.

--- a/lib/bucket_store/s3.rb
+++ b/lib/bucket_store/s3.rb
@@ -27,6 +27,8 @@ module BucketStore
         body: file,
       )
 
+      file.rewind
+
       {
         bucket: bucket,
         key: key,

--- a/lib/bucket_store/s3.rb
+++ b/lib/bucket_store/s3.rb
@@ -20,11 +20,11 @@ module BucketStore
       )
     end
 
-    def upload!(bucket:, key:, content:)
+    def upload!(bucket:, key:, file:)
       storage.put_object(
         bucket: bucket,
         key: key,
-        body: content,
+        body: file,
       )
 
       {

--- a/lib/bucket_store/s3.rb
+++ b/lib/bucket_store/s3.rb
@@ -33,17 +33,12 @@ module BucketStore
       }
     end
 
-    def download(bucket:, key:)
-      file = storage.get_object(
+    def download(bucket:, key:, file:)
+      storage.get_object(
+        response_target: file,
         bucket: bucket,
         key: key,
       )
-
-      {
-        bucket: bucket,
-        key: key,
-        content: file.body.read,
-      }
     end
 
     def list(bucket:, key:, page_size:)

--- a/lib/bucket_store/s3.rb
+++ b/lib/bucket_store/s3.rb
@@ -27,8 +27,6 @@ module BucketStore
         body: file,
       )
 
-      file.rewind
-
       {
         bucket: bucket,
         key: key,

--- a/lib/bucket_store/version.rb
+++ b/lib/bucket_store/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BucketStore
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end

--- a/spec/bucket_store/disk_spec.rb
+++ b/spec/bucket_store/disk_spec.rb
@@ -111,11 +111,11 @@ RSpec.describe BucketStore::Disk do
 
     context "when the bucket has some keys in it" do
       before do
-        instance.upload!(bucket: bucket, key: "2019-01/hello1", file: file)
-        instance.upload!(bucket: bucket, key: "2019-01/hello2", file: file)
-        instance.upload!(bucket: bucket, key: "2019-01/hello3", file: file)
-        instance.upload!(bucket: bucket, key: "2019-02/hello", file: file)
-        instance.upload!(bucket: bucket, key: "2019-03/hello", file: file)
+        instance.upload!(bucket: bucket, key: "2019-01/hello1", file: StringIO.new("world"))
+        instance.upload!(bucket: bucket, key: "2019-01/hello2", file: StringIO.new("world"))
+        instance.upload!(bucket: bucket, key: "2019-01/hello3", file: StringIO.new("world"))
+        instance.upload!(bucket: bucket, key: "2019-02/hello", file: StringIO.new("world"))
+        instance.upload!(bucket: bucket, key: "2019-03/hello", file: StringIO.new("world"))
       end
 
       context "and we provide a matching prefix" do

--- a/spec/bucket_store/in_memory_spec.rb
+++ b/spec/bucket_store/in_memory_spec.rb
@@ -122,11 +122,11 @@ RSpec.describe BucketStore::InMemory do
 
     context "when there's some content" do
       before do
-        instance.upload!(bucket: bucket, key: "2019-01/hello1", file: file)
-        instance.upload!(bucket: bucket, key: "2019-01/hello2", file: file)
-        instance.upload!(bucket: bucket, key: "2019-01/hello3", file: file)
-        instance.upload!(bucket: bucket2, key: "2019-02/hello", file: file)
-        instance.upload!(bucket: bucket2, key: "2019-03/hello", file: file)
+        instance.upload!(bucket: bucket, key: "2019-01/hello1", file: StringIO.new("world"))
+        instance.upload!(bucket: bucket, key: "2019-01/hello2", file: StringIO.new("world"))
+        instance.upload!(bucket: bucket, key: "2019-01/hello3", file: StringIO.new("world"))
+        instance.upload!(bucket: bucket2, key: "2019-02/hello", file: StringIO.new("world"))
+        instance.upload!(bucket: bucket2, key: "2019-03/hello", file: StringIO.new("world"))
       end
 
       it "resets all the buckets" do

--- a/spec/bucket_store/in_memory_spec.rb
+++ b/spec/bucket_store/in_memory_spec.rb
@@ -9,9 +9,12 @@ RSpec.describe BucketStore::InMemory do
 
   let(:bucket) { "bucket" }
 
+  let(:original_content) { "world" }
+  let(:file) { StringIO.new(original_content) }
+
   describe "#upload!" do
     it "uploads the given content" do
-      instance.upload!(bucket: bucket, key: "hello", content: "world")
+      instance.upload!(bucket: bucket, key: "hello", file: file)
 
       expect(instance.download(bucket: bucket, key: "hello")).to eq(
         bucket: bucket,
@@ -21,10 +24,10 @@ RSpec.describe BucketStore::InMemory do
     end
 
     context "when uploading over a key that already exists" do
-      before { instance.upload!(bucket: bucket, key: "hello", content: "world") }
+      before { instance.upload!(bucket: bucket, key: "hello", file: file) }
 
       it "overrides the content" do
-        instance.upload!(bucket: bucket, key: "hello", content: "planet")
+        instance.upload!(bucket: bucket, key: "hello", file: StringIO.new("planet"))
 
         expect(instance.download(bucket: bucket, key: "hello")).to eq(
           bucket: bucket,
@@ -44,7 +47,7 @@ RSpec.describe BucketStore::InMemory do
     end
 
     context "when the key has been uploaded" do
-      before { instance.upload!(bucket: bucket, key: "hello", content: "world") }
+      before { instance.upload!(bucket: bucket, key: "hello", file: file) }
 
       it "returns the uploaded content" do
         expect(instance.download(bucket: bucket, key: "hello")).to eq(
@@ -71,11 +74,11 @@ RSpec.describe BucketStore::InMemory do
 
     context "when the bucket has some keys in it" do
       before do
-        instance.upload!(bucket: bucket, key: "2019-01/hello1", content: "world")
-        instance.upload!(bucket: bucket, key: "2019-01/hello2", content: "world")
-        instance.upload!(bucket: bucket, key: "2019-01/hello3", content: "world")
-        instance.upload!(bucket: bucket, key: "2019-02/hello", content: "world")
-        instance.upload!(bucket: bucket, key: "2019-03/hello", content: "world")
+        instance.upload!(bucket: bucket, key: "2019-01/hello1", file: file)
+        instance.upload!(bucket: bucket, key: "2019-01/hello2", file: file)
+        instance.upload!(bucket: bucket, key: "2019-01/hello3", file: file)
+        instance.upload!(bucket: bucket, key: "2019-02/hello", file: file)
+        instance.upload!(bucket: bucket, key: "2019-03/hello", file: file)
       end
 
       context "and we provide a matching prefix" do
@@ -124,11 +127,11 @@ RSpec.describe BucketStore::InMemory do
 
     context "when there's some content" do
       before do
-        instance.upload!(bucket: bucket, key: "2019-01/hello1", content: "world")
-        instance.upload!(bucket: bucket, key: "2019-01/hello2", content: "world")
-        instance.upload!(bucket: bucket, key: "2019-01/hello3", content: "world")
-        instance.upload!(bucket: bucket2, key: "2019-02/hello", content: "world")
-        instance.upload!(bucket: bucket2, key: "2019-03/hello", content: "world")
+        instance.upload!(bucket: bucket, key: "2019-01/hello1", file: file)
+        instance.upload!(bucket: bucket, key: "2019-01/hello2", file: file)
+        instance.upload!(bucket: bucket, key: "2019-01/hello3", file: file)
+        instance.upload!(bucket: bucket2, key: "2019-02/hello", file: file)
+        instance.upload!(bucket: bucket2, key: "2019-03/hello", file: file)
       end
 
       it "resets all the buckets" do
@@ -149,7 +152,7 @@ RSpec.describe BucketStore::InMemory do
   end
 
   describe "#delete!" do
-    before { instance.upload!(bucket: bucket, key: "hello", content: "world") }
+    before { instance.upload!(bucket: bucket, key: "hello", file: file) }
 
     it "deletes the given content" do
       expect(instance.delete!(bucket: bucket, key: "hello")).to eq(true)

--- a/spec/bucket_store/key_storage_spec.rb
+++ b/spec/bucket_store/key_storage_spec.rb
@@ -115,33 +115,6 @@ RSpec.describe BucketStore::KeyStorage do
           to raise_error(ArgumentError, /key cannot be empty/i)
       end
     end
-
-    context "when given a file like object" do
-      let(:file) { StringIO.new("hello") }
-
-      it "uploads the given file" do
-        expect(build_for("inmemory://bucket/file1").upload!(file)).
-          to eq("inmemory://bucket/file1")
-      end
-
-      it "logs the operation" do
-        expect(BucketStore.logger).to receive(:info).with(
-          hash_including(event: "key_storage.upload_started"),
-        )
-        expect(BucketStore.logger).to receive(:info).with(
-          hash_including(event: "key_storage.upload_finished"),
-        )
-
-        build_for("inmemory://bucket/file1").upload!(file)
-      end
-
-      context "when we try to upload a bucket" do
-        it "raises an error" do
-          expect { build_for("inmemory://bucket").upload!(file) }.
-            to raise_error(ArgumentError, /key cannot be empty/i)
-        end
-      end
-    end
   end
 
   describe "#delete!" do

--- a/spec/bucket_store/key_storage_spec.rb
+++ b/spec/bucket_store/key_storage_spec.rb
@@ -115,31 +115,31 @@ RSpec.describe BucketStore::KeyStorage do
           to raise_error(ArgumentError, /key cannot be empty/i)
       end
     end
-  end
 
-  describe "#upload_file!" do
-    let(:file) { StringIO.new("hello") }
+    context "when given a file like object" do
+      let(:file) { StringIO.new("hello") }
 
-    it "uploads the given file" do
-      expect(build_for("inmemory://bucket/file1").upload_file!(file)).
-        to eq("inmemory://bucket/file1")
-    end
+      it "uploads the given file" do
+        expect(build_for("inmemory://bucket/file1").upload!(file)).
+          to eq("inmemory://bucket/file1")
+      end
 
-    it "logs the operation" do
-      expect(BucketStore.logger).to receive(:info).with(
-        hash_including(event: "key_storage.upload_file_started"),
-      )
-      expect(BucketStore.logger).to receive(:info).with(
-        hash_including(event: "key_storage.upload_file_finished"),
-      )
+      it "logs the operation" do
+        expect(BucketStore.logger).to receive(:info).with(
+          hash_including(event: "key_storage.upload_started"),
+        )
+        expect(BucketStore.logger).to receive(:info).with(
+          hash_including(event: "key_storage.upload_finished"),
+        )
 
-      build_for("inmemory://bucket/file1").upload_file!(file)
-    end
+        build_for("inmemory://bucket/file1").upload!(file)
+      end
 
-    context "when we try to upload a bucket" do
-      it "raises an error" do
-        expect { build_for("inmemory://bucket").upload_file!(file) }.
-          to raise_error(ArgumentError, /key cannot be empty/i)
+      context "when we try to upload a bucket" do
+        it "raises an error" do
+          expect { build_for("inmemory://bucket").upload!(file) }.
+            to raise_error(ArgumentError, /key cannot be empty/i)
+        end
       end
     end
   end

--- a/spec/bucket_store/key_storage_spec.rb
+++ b/spec/bucket_store/key_storage_spec.rb
@@ -133,8 +133,6 @@ RSpec.describe BucketStore::KeyStorage do
     end
 
     describe "#download" do
-      let(:input_file_1) { StringIO.new("content1") }
-      let(:input_file_2) { StringIO.new("content") }
       let(:output_file) { StringIO.new }
 
       before do
@@ -151,8 +149,8 @@ RSpec.describe BucketStore::KeyStorage do
           build_for("inmemory://bucket/file1").
           stream.
           download(file: output_file),
-        ).
-          to match(hash_including(file: output_file))
+        ).to match(hash_including(file: output_file))
+
         expect(output_file.string).to eq("content1")
       end
 

--- a/spec/bucket_store/key_storage_spec.rb
+++ b/spec/bucket_store/key_storage_spec.rb
@@ -75,10 +75,10 @@ RSpec.describe BucketStore::KeyStorage do
 
     it "logs the operation" do
       expect(BucketStore.logger).to receive(:info).with(
-        hash_including(event: "key_storage.stream.download_started"),
+        hash_including(event: "key_storage.download_started"),
       )
       expect(BucketStore.logger).to receive(:info).with(
-        hash_including(event: "key_storage.stream.download_finished"),
+        hash_including(event: "key_storage.download_finished"),
       )
 
       build_for("inmemory://bucket/file1").download
@@ -100,10 +100,10 @@ RSpec.describe BucketStore::KeyStorage do
 
     it "logs the operation" do
       expect(BucketStore.logger).to receive(:info).with(
-        hash_including(event: "key_storage.stream.upload_started"),
+        hash_including(event: "key_storage.upload_started"),
       )
       expect(BucketStore.logger).to receive(:info).with(
-        hash_including(event: "key_storage.stream.upload_finished"),
+        hash_including(event: "key_storage.upload_finished"),
       )
 
       build_for("inmemory://bucket/file1").upload!("hello")
@@ -158,10 +158,10 @@ RSpec.describe BucketStore::KeyStorage do
 
       it "logs the operation" do
         expect(BucketStore.logger).to receive(:info).with(
-          hash_including(event: "key_storage.stream.download_started"),
+          hash_including(event: "key_storage.download_started"),
         )
         expect(BucketStore.logger).to receive(:info).with(
-          hash_including(event: "key_storage.stream.download_finished"),
+          hash_including(event: "key_storage.download_finished"),
         )
 
         build_for("inmemory://bucket/file1").stream.download(file: output_file)
@@ -183,10 +183,10 @@ RSpec.describe BucketStore::KeyStorage do
 
       it "logs the operation" do
         expect(BucketStore.logger).to receive(:info).with(
-          hash_including(event: "key_storage.stream.upload_started"),
+          hash_including(event: "key_storage.upload_started"),
         )
         expect(BucketStore.logger).to receive(:info).with(
-          hash_including(event: "key_storage.stream.upload_finished"),
+          hash_including(event: "key_storage.upload_finished"),
         )
 
         stream.upload!(file: StringIO.new("hello"))

--- a/spec/bucket_store/key_storage_spec.rb
+++ b/spec/bucket_store/key_storage_spec.rb
@@ -117,6 +117,33 @@ RSpec.describe BucketStore::KeyStorage do
     end
   end
 
+  describe "#upload_file!" do
+    let(:file) { StringIO.new("hello") }
+
+    it "uploads the given file" do
+      expect(build_for("inmemory://bucket/file1").upload_file!(file)).
+        to eq("inmemory://bucket/file1")
+    end
+
+    it "logs the operation" do
+      expect(BucketStore.logger).to receive(:info).with(
+        hash_including(event: "key_storage.upload_file_started"),
+      )
+      expect(BucketStore.logger).to receive(:info).with(
+        hash_including(event: "key_storage.upload_file_finished"),
+      )
+
+      build_for("inmemory://bucket/file1").upload_file!(file)
+    end
+
+    context "when we try to upload a bucket" do
+      it "raises an error" do
+        expect { build_for("inmemory://bucket").upload_file!(file) }.
+          to raise_error(ArgumentError, /key cannot be empty/i)
+      end
+    end
+  end
+
   describe "#delete!" do
     before do
       build_for("inmemory://bucket/file1").upload!("content1")

--- a/spec/bucket_store/key_storage_spec.rb
+++ b/spec/bucket_store/key_storage_spec.rb
@@ -75,10 +75,10 @@ RSpec.describe BucketStore::KeyStorage do
 
     it "logs the operation" do
       expect(BucketStore.logger).to receive(:info).with(
-        hash_including(event: "key_storage.download_started"),
+        hash_including(event: "key_storage.stream.download_started"),
       )
       expect(BucketStore.logger).to receive(:info).with(
-        hash_including(event: "key_storage.download_finished"),
+        hash_including(event: "key_storage.stream.download_finished"),
       )
 
       build_for("inmemory://bucket/file1").download
@@ -100,10 +100,10 @@ RSpec.describe BucketStore::KeyStorage do
 
     it "logs the operation" do
       expect(BucketStore.logger).to receive(:info).with(
-        hash_including(event: "key_storage.upload_started"),
+        hash_including(event: "key_storage.stream.upload_started"),
       )
       expect(BucketStore.logger).to receive(:info).with(
-        hash_including(event: "key_storage.upload_finished"),
+        hash_including(event: "key_storage.stream.upload_finished"),
       )
 
       build_for("inmemory://bucket/file1").upload!("hello")
@@ -113,6 +113,90 @@ RSpec.describe BucketStore::KeyStorage do
       it "raises an error" do
         expect { build_for("inmemory://bucket").upload!("content") }.
           to raise_error(ArgumentError, /key cannot be empty/i)
+      end
+    end
+  end
+
+  describe "#stream" do
+    let(:stream) { build_for("inmemory://bucket/file1").stream }
+
+    it "will return an object" do
+      expect { stream }.to_not raise_error
+      expect(stream).to_not be_nil
+    end
+
+    context "when we try to upload a bucket" do
+      it "raises an error" do
+        expect { build_for("inmemory://bucket").stream }.
+          to raise_error(ArgumentError, /key cannot be empty/i)
+      end
+    end
+
+    describe "#download" do
+      let(:input_file_1) { StringIO.new("content1") }
+      let(:input_file_2) { StringIO.new("content") }
+      let(:output_file) { StringIO.new }
+
+      before do
+        build_for("inmemory://bucket/file1").
+          stream.
+          upload!(file: StringIO.new("content1"))
+        build_for("inmemory://bucket/file2").
+          stream.
+          upload!(file: StringIO.new("content2"))
+      end
+
+      it "downloads the given file" do
+        expect(
+          build_for("inmemory://bucket/file1").
+          stream.
+          download(file: output_file),
+        ).
+          to match(hash_including(file: output_file))
+        expect(output_file.string).to eq("content1")
+      end
+
+      it "logs the operation" do
+        expect(BucketStore.logger).to receive(:info).with(
+          hash_including(event: "key_storage.stream.download_started"),
+        )
+        expect(BucketStore.logger).to receive(:info).with(
+          hash_including(event: "key_storage.stream.download_finished"),
+        )
+
+        build_for("inmemory://bucket/file1").stream.download(file: output_file)
+      end
+
+      context "when we try to download a bucket" do
+        it "raises an error" do
+          expect { build_for("inmemory://bucket").download }.
+            to raise_error(ArgumentError, /key cannot be empty/i)
+        end
+      end
+    end
+
+    describe "#upload!" do
+      it "will upload from a file" do
+        expect(stream.upload!(file: StringIO.new("hello"))).
+          to eq("inmemory://bucket/file1")
+      end
+
+      it "logs the operation" do
+        expect(BucketStore.logger).to receive(:info).with(
+          hash_including(event: "key_storage.stream.upload_started"),
+        )
+        expect(BucketStore.logger).to receive(:info).with(
+          hash_including(event: "key_storage.stream.upload_finished"),
+        )
+
+        stream.upload!(file: StringIO.new("hello"))
+      end
+
+      context "when we try to upload a bucket" do
+        it "raises an error" do
+          expect { build_for("inmemory://bucket").upload!("content") }.
+            to raise_error(ArgumentError, /key cannot be empty/i)
+        end
       end
     end
   end

--- a/spec/bucket_store_integration_spec.rb
+++ b/spec/bucket_store_integration_spec.rb
@@ -24,54 +24,56 @@ RSpec.describe BucketStore, :integration do
   end
 
   shared_examples "adapter integration" do |base_bucket_uri|
-    before do
-      described_class.for(base_bucket_uri).list.each do |path|
-        described_class.for(path).delete!
-      end
-    end
-
-    it "has a consistent interface" do
-      # Write 201 files
-      file_list = []
-      201.times do |i|
-        filename = "file#{(i + 1).to_s.rjust(3, '0')}.txt"
-        file_list << filename
-
-        # the body of the file is the filename itself
-        described_class.for("#{base_bucket_uri}/prefix/#{filename}").upload!(filename)
+    context "using #{base_bucket_uri}" do
+      before do
+        described_class.for(base_bucket_uri).list.each do |path|
+          described_class.for(path).delete!
+        end
       end
 
-      # Add some files with spaces
-      described_class.for("#{base_bucket_uri}/prefix/i have a space.txt").
-        upload!("i have a space.txt")
-      described_class.for("#{base_bucket_uri}/prefix/another space.txt").
-        upload!("another space.txt")
+      it "has a consistent interface" do
+        # Write 201 files
+        file_list = []
+        201.times do |i|
+          filename = "file#{(i + 1).to_s.rjust(3, '0')}.txt"
+          file_list << filename
 
-      file_list << "i have a space.txt"
-      file_list << "another space.txt"
+          # the body of the file is the filename itself
+          described_class.for("#{base_bucket_uri}/prefix/#{filename}").upload!(filename)
+        end
 
-      # List with prefix should only return the matching files
-      expect(described_class.for("#{base_bucket_uri}/prefix/file1").list.to_a.size).to eq(100)
-      expect(described_class.for("#{base_bucket_uri}/prefix/file2").list.to_a.size).to eq(2)
-      expect(described_class.for("#{base_bucket_uri}/prefix/").list.to_a.size).to eq(203)
+        # Add some files with spaces
+        described_class.for("#{base_bucket_uri}/prefix/i have a space.txt").
+          upload!("i have a space.txt")
+        described_class.for("#{base_bucket_uri}/prefix/another space.txt").
+          upload!("another space.txt")
 
-      # List (without prefixes) should return everything
-      expect(described_class.for(base_bucket_uri.to_s).list.to_a).
-        to match_array(file_list.map { |filename| "#{base_bucket_uri}/prefix/#{filename}" })
+        file_list << "i have a space.txt"
+        file_list << "another space.txt"
 
-      # We know the content of the file, we can check `.download` returns it as expected
-      all_files = file_list.map do |filename|
-        [filename, "#{base_bucket_uri}/prefix/#{filename}"]
+        # List with prefix should only return the matching files
+        expect(described_class.for("#{base_bucket_uri}/prefix/file1").list.to_a.size).to eq(100)
+        expect(described_class.for("#{base_bucket_uri}/prefix/file2").list.to_a.size).to eq(2)
+        expect(described_class.for("#{base_bucket_uri}/prefix/").list.to_a.size).to eq(203)
+
+        # List (without prefixes) should return everything
+        expect(described_class.for(base_bucket_uri.to_s).list.to_a).
+          to match_array(file_list.map { |filename| "#{base_bucket_uri}/prefix/#{filename}" })
+
+        # We know the content of the file, we can check `.download` returns it as expected
+        all_files = file_list.map do |filename|
+          [filename, "#{base_bucket_uri}/prefix/#{filename}"]
+        end
+        all_files.each do |content, key|
+          expect(described_class.for(key).download[:content]).to eq(content)
+        end
+
+        # Delete all the files, the bucket should be empty afterwards
+        described_class.for(base_bucket_uri.to_s).list.each do |key|
+          described_class.for(key).delete!
+        end
+        expect(described_class.for(base_bucket_uri.to_s).list.to_a.size).to eq(0)
       end
-      all_files.each do |content, key|
-        expect(described_class.for(key).download[:content]).to eq(content)
-      end
-
-      # Delete all the files, the bucket should be empty afterwards
-      file_list.map { |filename| "#{base_bucket_uri}/prefix/#{filename}" }.each do |key|
-        described_class.for(key).delete!
-      end
-      expect(described_class.for(base_bucket_uri.to_s).list.to_a.size).to eq(0)
     end
   end
 

--- a/spec/bucket_store_integration_spec.rb
+++ b/spec/bucket_store_integration_spec.rb
@@ -4,6 +4,8 @@ require "spec_helper"
 
 require "aws-sdk-s3"
 
+require "tempfile"
+
 RSpec.describe BucketStore, :integration do
   before do
     # Setup AWS connectivity to minio
@@ -31,7 +33,110 @@ RSpec.describe BucketStore, :integration do
         end
       end
 
-      it "has a consistent interface" do
+      context "when handling streaming uploads / downloads" do
+        let(:temp_filename) { "temp-file" }
+        let(:buffer_filename) { "in-memory-buffer" }
+        let(:input_temp_file) do
+          Tempfile.new.tap do |file|
+            file.write(Random.base64(1024))
+            file.rewind
+          end
+        end
+        let(:output_temp_file) do
+          Tempfile.new
+        end
+
+        let(:input_in_memory_buffer) do
+          StringIO.new(Random.base64(1024))
+        end
+        let(:output_in_memory_buffer) do
+          StringIO.new
+        end
+
+        before do
+          described_class.for("#{base_bucket_uri}/#{temp_filename}").
+            stream.
+            upload!(file: input_temp_file)
+          input_temp_file.rewind
+
+          described_class.for("#{base_bucket_uri}/#{buffer_filename}").
+            stream.
+            upload!(file: input_in_memory_buffer)
+          input_in_memory_buffer.rewind
+        end
+
+        after do
+          input_temp_file.close
+          output_temp_file.close
+        end
+
+        it "all file are listable on the store" do
+          expect(described_class.for(base_bucket_uri.to_s).list.to_a.size).to eq(2)
+        end
+
+        it "files are deletable on the store" do
+          described_class.for(base_bucket_uri.to_s).list.each do |key|
+            described_class.for(key).delete!
+          end
+          expect(described_class.for(base_bucket_uri.to_s).list.to_a.size).to eq(0)
+        end
+
+        it "files are downloadable from the store" do
+          described_class.for("#{base_bucket_uri}/#{temp_filename}").
+            stream.
+            download(file: output_temp_file)
+          output_temp_file.rewind
+
+          expect(output_temp_file.read).to eq(input_temp_file.read)
+
+          described_class.for("#{base_bucket_uri}/#{buffer_filename}").
+            stream.
+            download(file: output_in_memory_buffer)
+          output_in_memory_buffer.rewind
+
+          expect(output_in_memory_buffer.read).to eq(input_in_memory_buffer.read)
+        end
+
+        context "when the files are binary" do
+          let(:input_temp_file) do
+            Tempfile.new.binmode.tap do |file|
+              file.write(Random.bytes(1024))
+              file.rewind
+            end
+          end
+          let(:output_temp_file) do
+            Tempfile.new.binmode
+          end
+
+          let(:input_in_memory_buffer) do
+            StringIO.new.binmode.tap do |buffer|
+              buffer.write(Random.bytes(1024))
+              buffer.rewind
+            end
+          end
+          let(:output_in_memory_buffer) do
+            StringIO.new.binmode
+          end
+
+          it "files are downloadable from the store" do
+            described_class.for("#{base_bucket_uri}/#{temp_filename}").
+              stream.
+              download(file: output_temp_file)
+            output_temp_file.rewind
+
+            expect(output_temp_file.read).to eq(input_temp_file.read)
+
+            described_class.for("#{base_bucket_uri}/#{buffer_filename}").
+              stream.
+              download(file: output_in_memory_buffer)
+            output_in_memory_buffer.rewind
+
+            expect(output_in_memory_buffer.read).to eq(input_in_memory_buffer.read)
+          end
+        end
+      end
+
+      it "has a consistent interface for string uploads / downloads" do
         # Write 201 files
         file_list = []
         201.times do |i|
@@ -77,7 +182,6 @@ RSpec.describe BucketStore, :integration do
     end
   end
 
-  # We don't test GCS as there's no sensible way of running a local simulator
   include_examples "adapter integration", "inmemory://bucket"
   include_examples "adapter integration", "disk://bucket"
   include_examples "adapter integration", "s3://bucket"

--- a/spec/bucket_store_integration_spec.rb
+++ b/spec/bucket_store_integration_spec.rb
@@ -57,12 +57,10 @@ RSpec.describe BucketStore, :integration do
           described_class.for("#{base_bucket_uri}/#{temp_filename}").
             stream.
             upload!(file: input_temp_file)
-          input_temp_file.rewind
 
           described_class.for("#{base_bucket_uri}/#{buffer_filename}").
             stream.
             upload!(file: input_in_memory_buffer)
-          input_in_memory_buffer.rewind
         end
 
         after do
@@ -85,14 +83,12 @@ RSpec.describe BucketStore, :integration do
           described_class.for("#{base_bucket_uri}/#{temp_filename}").
             stream.
             download(file: output_temp_file)
-          output_temp_file.rewind
 
           expect(output_temp_file.read).to eq(input_temp_file.read)
 
           described_class.for("#{base_bucket_uri}/#{buffer_filename}").
             stream.
             download(file: output_in_memory_buffer)
-          output_in_memory_buffer.rewind
 
           expect(output_in_memory_buffer.read).to eq(input_in_memory_buffer.read)
         end
@@ -122,14 +118,12 @@ RSpec.describe BucketStore, :integration do
             described_class.for("#{base_bucket_uri}/#{temp_filename}").
               stream.
               download(file: output_temp_file)
-            output_temp_file.rewind
 
             expect(output_temp_file.read).to eq(input_temp_file.read)
 
             described_class.for("#{base_bucket_uri}/#{buffer_filename}").
               stream.
               download(file: output_in_memory_buffer)
-            output_in_memory_buffer.rewind
 
             expect(output_in_memory_buffer.read).to eq(input_in_memory_buffer.read)
           end

--- a/spec/bucket_store_integration_spec.rb
+++ b/spec/bucket_store_integration_spec.rb
@@ -24,8 +24,11 @@ RSpec.describe BucketStore, :integration do
   end
 
   shared_examples "adapter integration" do |base_bucket_uri|
-    # This is presented as a single idempotent test as otherwise resetting state between execution
-    # makes things very complicated with no huge benefits.
+    before do
+      described_class.for(base_bucket_uri).list.each do |path|
+        described_class.for(path).delete!
+      end
+    end
 
     it "has a consistent interface" do
       # Write 201 files

--- a/spec/bucket_store_integration_spec.rb
+++ b/spec/bucket_store_integration_spec.rb
@@ -6,6 +6,8 @@ require "aws-sdk-s3"
 
 require "tempfile"
 
+require "pry-byebug"
+
 RSpec.describe BucketStore, :integration do
   before do
     # Setup AWS connectivity to minio
@@ -66,8 +68,17 @@ RSpec.describe BucketStore, :integration do
         end
 
         after do
-          input_temp_file.close
-          output_temp_file.close
+          if input_temp_file.is_a?(File)
+            input_temp_file.close
+          else
+            input_temp_file.unlink
+          end
+
+          if output_temp_file.is_a?(File)
+            output_temp_file.close
+          else
+            output_temp_file.unlink
+          end
         end
 
         it "all file are listable on the store" do

--- a/spec/bucket_store_integration_spec.rb
+++ b/spec/bucket_store_integration_spec.rb
@@ -57,10 +57,12 @@ RSpec.describe BucketStore, :integration do
           described_class.for("#{base_bucket_uri}/#{temp_filename}").
             stream.
             upload!(file: input_temp_file)
+          input_temp_file.rewind
 
           described_class.for("#{base_bucket_uri}/#{buffer_filename}").
             stream.
             upload!(file: input_in_memory_buffer)
+          input_in_memory_buffer.rewind
         end
 
         after do

--- a/spec/bucket_store_integration_spec.rb
+++ b/spec/bucket_store_integration_spec.rb
@@ -6,8 +6,6 @@ require "aws-sdk-s3"
 
 require "tempfile"
 
-require "pry-byebug"
-
 RSpec.describe BucketStore, :integration do
   before do
     # Setup AWS connectivity to minio
@@ -68,17 +66,8 @@ RSpec.describe BucketStore, :integration do
         end
 
         after do
-          if input_temp_file.is_a?(File)
-            input_temp_file.close
-          else
-            input_temp_file.unlink
-          end
-
-          if output_temp_file.is_a?(File)
-            output_temp_file.close
-          else
-            output_temp_file.unlink
-          end
+          input_temp_file.close!
+          output_temp_file.close!
         end
 
         it "all file are listable on the store" do
@@ -108,13 +97,13 @@ RSpec.describe BucketStore, :integration do
 
         context "when the files are binary" do
           let(:input_temp_file) do
-            Tempfile.new.binmode.tap do |file|
+            Tempfile.new(binmode: true).tap do |file|
               file.write(Random.bytes(1024))
               file.rewind
             end
           end
           let(:output_temp_file) do
-            Tempfile.new.binmode
+            Tempfile.new(binmode: true)
           end
 
           let(:input_in_memory_buffer) do


### PR DESCRIPTION
This PR adds an additional `stream` API which allows uploads and downloads to be driven by IO like objects.

To do this it changes the way adapters work to think in terms of IO like objects for upload / download. It also maintains the existing String based interface by making it a special case of IO like operations e.g. we wrap Strings in `StringIO` to keep the API consistent.

This PR also steals a ton of content from #63 including whole commits / approach