### PR TITLE
Support for legacy in-memory storage behavior. In memory storage - persists encoding for upload / download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v0.6.1
+------
+- Support for legacy in-memory storage behavior
+   * In memory storage - persists encoding for upload / download
+
 v0.6.0
 ------
 - [BREAKING] Remove support for Ruby 2.6

--- a/lib/bucket_store/in_memory.rb
+++ b/lib/bucket_store/in_memory.rb
@@ -26,7 +26,10 @@ module BucketStore
 
     def upload!(bucket:, key:, file:)
       file.tap do |f|
-        @buckets[bucket][key] = f.read
+        @buckets[bucket][key] = {
+          data: f.read,
+          encoding: file.external_encoding,
+        }
       end
 
       {
@@ -37,7 +40,10 @@ module BucketStore
 
     def download(bucket:, key:, file:)
       file.tap do |f|
-        f.write(@buckets[bucket].fetch(key))
+        f.set_encoding(
+          @buckets[bucket].fetch(key).fetch(:encoding),
+        )
+        f.write(@buckets[bucket].fetch(key).fetch(:data))
         f.rewind
       end
     end

--- a/lib/bucket_store/version.rb
+++ b/lib/bucket_store/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BucketStore
-  VERSION = "0.6.0"
+  VERSION = "0.6.1"
 end


### PR DESCRIPTION
```ruby
    def download
      # Here we a create buffer with default encoding,
      # but with old in-memory behavior, we just read the string value (encoding wasn't lost)
      buffer = StringIO.new
      stream.download(file: buffer).tap do |result|
        result.delete(:file)
        result[:content] = buffer.string
      end
    end
```